### PR TITLE
Add ability to drop directly into year selection when selecting a date

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Wrap a input field in the <ct-date-picker> element. Mark the input field with #d
  * minDate - Minimum allowed date.
  * maxDate - Maximum allowed date.
  * match - Optional regex for properly parsing typed in dates, e.g. mm/dd/yyyy
+ * globalMode - Sets the starting mode for selecting a date, e.g. Calendar, Year. If no value is specified, Calendar mode is implied.
 
 
 ### Dual Date Picker
@@ -61,7 +62,7 @@ Wrap two input fields in the <ct-dual-picker> element. Mark each input #dateFrom
  * minDate - Minimum allowed date.
  * maxDate - Maximum allowed date.
  * match - Optional regex for properly parsing typed in dates, e.g. mm/dd/yyyy
-
+ * globalMode - Sets the starting mode for selecting a date, e.g. Calendar, Year. If no value is specified, Calendar mode is implied.
 
 ## Requirements
 - Angular 2+ (common, core, forms)

--- a/src/calendar/calendar.component.html
+++ b/src/calendar/calendar.component.html
@@ -3,11 +3,11 @@
 </div>
 <div class="ct-dp-months" [ngClass]="{'hidden': mode != CalendarMode.Month}">
     <template ngFor let-item [ngForOf]="months" [ngForTrackBy]="myTrackBy" let-i="index"><!--
-        --><button tabindex="-1" class="ct-dp-btn ct-dp-month" (click)="setMonth(i)">{{item}}</button>
+        --><button tabindex="-1" class="ct-dp-btn ct-dp-month" [disabled]="disableBtn(item, 'month')" (click)="setMonth(i)">{{item}}</button>
     </template>
 </div>
 <div class="ct-dp-years" [ngClass]="{'hidden': mode != CalendarMode.Year}">
     <template ngFor let-item [ngForOf]="years" [ngForTrackBy]="myTrackBy" let-i="index"><!--
-        --><button tabindex="-1" class="ct-dp-btn ct-dp-year" (click)="setYear(item)">{{item}}</button>
+        --><button tabindex="-1" class="ct-dp-btn ct-dp-year" [disabled]="disableBtn(item, 'year')" (click)="setYear(item)">{{item}}</button>
     </template>
 </div>

--- a/src/calendar/calendar.component.ts
+++ b/src/calendar/calendar.component.ts
@@ -19,7 +19,7 @@ export class CalendarComponent implements OnInit, OnDestroy {
     public mode: CalendarMode;
     /** Date object representing the month/year shown on this calendar */
     public date: moment.Moment;
-    /** Date object representing today.This hsould never change in the rendering of the calendar grid */
+    /** Date object representing today.This should never change in the rendering of the calendar grid */
     public today: moment.Moment;
     /** Array of months to show when selecting a new month */
     private months: string[] = [];
@@ -32,6 +32,10 @@ export class CalendarComponent implements OnInit, OnDestroy {
     private yearListeners: Function[] = [];
     /** Grid view child component (actually shows the number grid) */
     @ViewChild(CalendarGridComponent) public grid: CalendarGridComponent;
+    /** The minimum date allowed to select */
+    public minDate: moment.Moment;
+    /** The maximum date allowed to select */
+    public maxDate: moment.Moment;    
 
     constructor() {
         this.generateMonthData();
@@ -114,5 +118,15 @@ export class CalendarComponent implements OnInit, OnDestroy {
         for (let fn of this.yearListeners) {
             fn();
         }
+    }
+    disableBtn(item: number, unit: moment.unitOfTime.StartOf) {
+        let validDate: moment.Moment;
+        if (unit === 'year') {
+            validDate = moment({year: item, month: 0, day: 1})
+        }
+        if (unit === 'month') { // because of how we loop over the months, we have to get the number representation of the string month
+            validDate = moment({year: this.date.year(), month: moment().month(item).month(), day: 1})
+        }
+        return !validDate.isBetween(this.minDate, this.maxDate, unit, '[]')
     }
 }

--- a/src/calendar/calendar.component.ts
+++ b/src/calendar/calendar.component.ts
@@ -16,7 +16,7 @@ export class CalendarComponent implements OnInit, OnDestroy {
     private static halfNumYearsShown = Math.floor(CalendarComponent.numYearsShown / 2);
     /** Accessor to the mode for html */
     public CalendarMode = CalendarMode;
-    public mode: CalendarMode = CalendarMode.Year;
+    public mode: CalendarMode;
     /** Date object representing the month/year shown on this calendar */
     public date: moment.Moment;
     /** Date object representing today.This hsould never change in the rendering of the calendar grid */

--- a/src/calendar/calendar.component.ts
+++ b/src/calendar/calendar.component.ts
@@ -16,7 +16,7 @@ export class CalendarComponent implements OnInit, OnDestroy {
     private static halfNumYearsShown = Math.floor(CalendarComponent.numYearsShown / 2);
     /** Accessor to the mode for html */
     public CalendarMode = CalendarMode;
-    public mode: CalendarMode = CalendarMode.Calendar;
+    public mode: CalendarMode = CalendarMode.Year;
     /** Date object representing the month/year shown on this calendar */
     public date: moment.Moment;
     /** Date object representing today.This hsould never change in the rendering of the calendar grid */

--- a/src/common/common.less
+++ b/src/common/common.less
@@ -162,7 +162,7 @@
         background-color: white;
     }
     &[disabled]{
-        color: white;
+        color: @disabled;
     }
 }
 

--- a/src/common/datepicker-base.ts
+++ b/src/common/datepicker-base.ts
@@ -35,7 +35,7 @@ export abstract class DatePickerBase implements ControlValueAccessor {
     else {
       this.minDateVal = null;
     }
-  }
+  } get minDate() { return this.minDateVal }
   @Input('maxDate') set maxDate(val: any) {
     let d = moment(val);
     if (d.isValid()) {
@@ -44,7 +44,7 @@ export abstract class DatePickerBase implements ControlValueAccessor {
     else {
       this.maxDateVal = null;
     }
-  }
+  } get maxDate() { return this.maxDateVal }
 
   public registerOnChange(fn) {
     this.propagateChange = fn;

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -40,8 +40,6 @@ export class DatePickerComponent extends DatePickerBase implements AfterViewInit
       }
     }
   }
-
-  @Output() dateChange = new EventEmitter();
   private dateValue: moment.Moment;
   @Input()
   get date() {
@@ -67,7 +65,8 @@ export class DatePickerComponent extends DatePickerBase implements AfterViewInit
   set match(val) {
     this.validDateExpression = new RegExp(val);
   }
-
+  @Output() dateChange = new EventEmitter();
+  
   @ContentChild('date') input: ElementRef;
 
   @ViewChild(CalendarComponent) public cal: CalendarComponent;
@@ -188,6 +187,9 @@ export class DatePickerComponent extends DatePickerBase implements AfterViewInit
     } else {
       this.cal.date = moment();
     }
+
+    this.cal.minDate = this.minDate;
+    this.cal.maxDate = this.maxDate;
 
     this.cal.subscribeToChangeMonth(this.monthChangeListener);
     this.cal.subscribeToChangeYear(this.yearChangeListener);

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -29,6 +29,18 @@ export class DatePickerComponent extends DatePickerBase implements AfterViewInit
   public CalendarMode = CalendarMode;
   public DatePickerMode = DatePickerMode;
 
+  private _globalMode: CalendarMode = CalendarMode.Calendar;
+  /** Set the starting mode for selecting a date. (eg. Calendar, Month, Year) **/
+  @Input() set globalMode(val: string) { 
+    if (CalendarMode.hasOwnProperty(val)) {
+      switch(CalendarMode[`${val}`]) {
+        case CalendarMode.Calendar:
+        case CalendarMode.Year:
+          this._globalMode = CalendarMode[`${val}`]
+      }
+    }
+  }
+
   @Output() dateChange = new EventEmitter();
   private dateValue: moment.Moment;
   @Input()
@@ -88,7 +100,7 @@ export class DatePickerComponent extends DatePickerBase implements AfterViewInit
     this.mode = mode;
     switch (this.mode) {
       case DatePickerMode.Visible:
-        this.changeMode(CalendarMode.Calendar);
+        this.changeMode(this._globalMode);
         $(this.myElement.nativeElement).addClass("ct-dp-active");
         this.positionCalendar();
         break;

--- a/src/dualpicker/dualpicker.component.ts
+++ b/src/dualpicker/dualpicker.component.ts
@@ -37,6 +37,18 @@ export class DualPickerComponent extends DatePickerBase implements OnChanges {
     public CalendarMode = CalendarMode;
     public DualPickerMode = DualPickerMode;
 
+    private _globalMode: CalendarMode = CalendarMode.Month;
+    /** Set the starting mode for selecting a date. (eg. Calendar, Month, Year) **/
+    @Input() set globalMode(val: string) { 
+        if (CalendarMode.hasOwnProperty(val)) {
+            switch(CalendarMode[`${val}`]) {
+                case CalendarMode.Calendar:
+                case CalendarMode.Year:
+                this._globalMode = CalendarMode[`${val}`]
+            }
+        }
+    }
+
     /** Date from (binding value) */
     private dateFromValue: moment.Moment;
     /** Date to (binding value) */
@@ -134,8 +146,8 @@ export class DualPickerComponent extends DatePickerBase implements OnChanges {
                 this.hideCalendar();
                 break;
         }
-        this.changeMode(CalendarMode.Calendar, this.cal1);
-        this.changeMode(CalendarMode.Calendar, this.cal2);
+        this.changeMode(this._globalMode, this.cal1);
+        this.changeMode(this._globalMode, this.cal2);
     }
 
     private positionCalendar(element: ElementRef) {

--- a/src/dualpicker/dualpicker.component.ts
+++ b/src/dualpicker/dualpicker.component.ts
@@ -37,7 +37,7 @@ export class DualPickerComponent extends DatePickerBase implements OnChanges {
     public CalendarMode = CalendarMode;
     public DualPickerMode = DualPickerMode;
 
-    private _globalMode: CalendarMode = CalendarMode.Month;
+    private _globalMode: CalendarMode = CalendarMode.Calendar;
     /** Set the starting mode for selecting a date. (eg. Calendar, Month, Year) **/
     @Input() set globalMode(val: string) { 
         if (CalendarMode.hasOwnProperty(val)) {


### PR DESCRIPTION
We have needed the ability to start at selecting the year first when selecting a date. This allows for that when configured on either the date picker or dual date picker. If the config is not specified, then calendar mode is the default.

Updated the README to reflect what modes are supported.