### PR TITLE
Disconnect min and max dates

### DIFF
--- a/src/calendar-grid/calendar-grid.component.ts
+++ b/src/calendar-grid/calendar-grid.component.ts
@@ -69,8 +69,11 @@ export class CalendarGridComponent implements OnInit, OnDestroy {
             if (dateFrom && dateTo && d.isBetween(dateFrom, dateTo)) {
                 el.addClass("between");
             }
-            if (maxDate && minDate && d.isBefore(minDate) || d.isAfter(maxDate)) {
+            if (minDate && d.isBefore(minDate) ) {
                 el.attr("disabled", "disabled");
+            }
+            if (maxDate && d.isAfter(maxDate) ) {
+                el.attr("disabled", "disabled");                
             }
             el.click(clickCallback(d));
             d.date(d.date() + 1);


### PR DESCRIPTION
Adding the ability to specify only one side of the min and max date validation. Maybe I don't care what date in the future is selected, as long as the date selected is greater than a min date. Separating the min and max date disabled stuff allows for this.